### PR TITLE
WIP - Searching once the user stops writing

### DIFF
--- a/main.py
+++ b/main.py
@@ -172,3 +172,5 @@ app = App()
 
 
 
+if __name__ == "__main__":
+    app = App()

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ class App(ctk.CTk):
         self.main.iconbitmap("mainicon.ico")
         self.selected_font = ('Fixedsys', 12)
 
+        self._after_id = None
 
 
         #--------------------Settings Frame--------------------#
@@ -61,6 +62,8 @@ class App(ctk.CTk):
         self.query_entry = ctk.CTkEntry(self.entry_frame, width=180, border_width=1, placeholder_text="Search word...", text_font=('fixedsys',12))
         self.query_entry.grid(row=0, column=0, pady=5, padx=5)
         self.query_entry.bind("<Return>", lambda event: threading.Thread(target=self.SearchMeaning).start())
+        # self.query_entry.bind("<Key>", self.search_after_stop_writing)
+
 
         #preferred language
         self.language_entry = ctk.CTkEntry(self.entry_frame, text_font=self.selected_font, width=80, placeholder_text="language")
@@ -156,19 +159,19 @@ class App(ctk.CTk):
         meaning = self.search_results.get('1.0','end')
         clip.copy(meaning)
 
-        
-        
+    def search_after_stop_writing(self, event):
+        """
+        From https://stackoverflow.com/questions/37432598/wait-until-user-stopped-typing-in-tkinter.
+        It will wait an amount of milliseconds after the user stopped writing and start searching for
+        the word automatically if this function is bound to "<Key>".
+        """
+        # Cancels the old job, if it exists.
+        if self._after_id is not None:
+            self.main.after_cancel(self._after_id)
 
-    
-
-
-
-
-
-    
-
-app = App()
-
+        # Creates a new job: it will wait an amount of milliseconds after the user stopped writing
+        # and start searching for the word automatically.
+        self.main.after(2000, lambda: threading.Thread(target=self.SearchMeaning).start())
 
 
 

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import threading
 from tkinter import ANCHOR, BOTH, END, HORIZONTAL, LEFT, TOP, X
 from ttkwidgets.autocomplete import AutocompleteEntry
 import customtkinter as ctk
@@ -59,7 +60,7 @@ class App(ctk.CTk):
         #taking the query input
         self.query_entry = ctk.CTkEntry(self.entry_frame, width=180, border_width=1, placeholder_text="Search word...", text_font=('fixedsys',12))
         self.query_entry.grid(row=0, column=0, pady=5, padx=5)
-        self.query_entry.bind("<Return>", self.SearchMeaning)
+        self.query_entry.bind("<Return>", lambda event: threading.Thread(target=self.SearchMeaning).start())
 
         #preferred language
         self.language_entry = ctk.CTkEntry(self.entry_frame, text_font=self.selected_font, width=80, placeholder_text="language")


### PR DESCRIPTION
A few suggestions I added in these commits:

1. Do searches in the background (different thread);
2. Start searching automatically once the user stops typing (similarly to how google translate website works).

I implemented the basics of the above in these commits but they come with a few bugs due to the current implementation of SearchMeaning+the way I implemented threading. eg.: if you press enter twice everything will show up twice. 

I can think of two solutions: 
1. Probably easier but may end up making the user wait longer for a response: make it so everything is translated and saved up in a big string and only then you clear the screen and write the string -> Requires changing implementation of SearchMeaning; or;
2. Probably harder but faster response times: keep track of threads and only start a new one after an old one has joined (or only start a new one if there is no thread already running) -> Requires changing the way threads are handled/happening;

It's probably better if you create a WIP branch and merge these commits to it if you want to add this feature and work on it.

Btw I left the "Key" bind commented as it might cause the most bugs for now.